### PR TITLE
CI: add merge status check gatekeeper

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -1,0 +1,18 @@
+name: Merge Status Checks
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/frontend.iml
+++ b/frontend/frontend.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Adds a CI job using https://github.com/upsidr/merge-gatekeeper , as GitHub branch rulesets do not allow checking if one of the checks has passed, which is reuired for this repo, as CI jobs are only executed on changes to the specific project.